### PR TITLE
Fix pixel covariance script

### DIFF
--- a/python/examples/pixel_covariance.ipynb
+++ b/python/examples/pixel_covariance.ipynb
@@ -1,0 +1,183 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7fb27b941602401d91542211134fc71a",
+   "metadata": {},
+   "source": [
+    "# Pixel covariance visualization\n",
+    "This notebook loads the Jacobian, covariance and index files produced by COLMAP's `covariance_exporter` or the `BACovariance` API. It then computes the 2x2 pixel covariance for all observations in a given image and visualises its magnitude."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "acae54e37e7d407bbb7b55eff062a284",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "import numpy as np\n",
+    "from scipy import sparse\n",
+    "import matplotlib.pyplot as plt\n",
+    "import pycolmap"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9a63283cbaf04dbcab1f6479b197f3a8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Paths to the exported files\n",
+    "data_dir = Path(\"/path/to/project\")\n",
+    "jac_path = data_dir / \"jacobian.txt\"\n",
+    "cov_path = data_dir / \"covariance.txt\"\n",
+    "index_path = data_dir / \"index.txt\"\n",
+    "model_path = data_dir / \"sparse/optimized\"\n",
+    "image_id = 5  # image to analyse"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8dd0d8092fe74a7c96281538738b07e2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def read_sparse_matrix(path):\n",
+    "    with open(path) as f:\n",
+    "        rows, cols = map(int, f.readline().split())\n",
+    "        data, r, c = [], [], []\n",
+    "        for line in f:\n",
+    "            rr, cc, val = line.split()\n",
+    "            r.append(int(rr))\n",
+    "            c.append(int(cc))\n",
+    "            data.append(float(val))\n",
+    "    return sparse.csr_matrix((data, (r, c)), shape=(rows, cols))\n",
+    "\n",
+    "\n",
+    "def read_dense_matrix(path):\n",
+    "    return np.loadtxt(path)\n",
+    "\n",
+    "\n",
+    "def read_index(path):\n",
+    "    mapping = {}\n",
+    "    with open(path) as f:\n",
+    "        for line in f:\n",
+    "            name, start, size = line.split()\n",
+    "            mapping[name] = (int(start), int(size))\n",
+    "    return mapping"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "72eea5119410473aa328ad9291626812",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "J = read_sparse_matrix(jac_path)\n",
+    "C = read_dense_matrix(cov_path)\n",
+    "index = read_index(index_path)\n",
+    "rec = pycolmap.Reconstruction(model_path)\n",
+    "img = rec.images[image_id]\n",
+    "cam = rec.cameras[img.camera_id]\n",
+    "height, width = cam.height, cam.width"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8edb47106e1a46a883d545849b8ab81b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Map residual rows to observations assuming COLMAP's default ordering\n",
+    "obs_info = []\n",
+    "row = 0\n",
+    "for iid in sorted(rec.reg_image_ids()):\n",
+    "    im = rec.images[iid]\n",
+    "    for idx, p2d in enumerate(im.points2D):\n",
+    "        if not p2d.has_point3D():\n",
+    "            continue\n",
+    "        obs_info.append((iid, idx, p2d.point3D_id, row, p2d.xy))\n",
+    "        row += 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10185d26023b46108eb7d9f57d49d2b3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vals = []\n",
+    "coords = []\n",
+    "for iid, idx, pid, row_start, xy in obs_info:\n",
+    "    if iid != image_id:\n",
+    "        continue\n",
+    "    rows = slice(row_start, row_start + 2)\n",
+    "    cols = []\n",
+    "    rot_s, rot_sz = index.get(f\"pose_{iid}_rot\", (0, 0))\n",
+    "    trans_s, trans_sz = index.get(f\"pose_{iid}_trans\", (0, 0))\n",
+    "    cols += list(range(rot_s, rot_s + rot_sz))\n",
+    "    cols += list(range(trans_s, trans_s + trans_sz))\n",
+    "    pt_key = f\"point_{pid}\"\n",
+    "    if pt_key in index:\n",
+    "        ps, psz = index[pt_key]\n",
+    "        if ps + psz <= C.shape[0]:\n",
+    "            cols += list(range(ps, ps + psz))\n",
+    "    J_block = J[rows, :][:, cols].toarray()\n",
+    "    C_sub = C[np.ix_(cols, cols)]\n",
+    "    cov = J_block @ C_sub @ J_block.T\n",
+    "    val = np.linalg.norm(cov, \"fro\")\n",
+    "    vals.append(val)\n",
+    "    coords.append(xy)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8763a12b2bbd4a93a75aff182afb95dc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vals = np.array(vals)\n",
+    "print(\"min\", vals.min(), \"max\", vals.max(), \"mean\", vals.mean())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7623eae2785240b9bd12b16a66d81610",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "img_cov = np.zeros((height, width), dtype=float)\n",
+    "for (x, y), v in zip(coords, vals):\n",
+    "    xi, yi = int(round(x)), int(round(y))\n",
+    "    if 0 <= yi < height and 0 <= xi < width:\n",
+    "        img_cov[yi, xi] = v\n",
+    "plt.imshow(img_cov, cmap=\"inferno\")\n",
+    "plt.colorbar(label=\"pixel covariance magnitude\")\n",
+    "plt.title(f\"Image {image_id}\")\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/colmap/controllers/option_manager.cc
+++ b/src/colmap/controllers/option_manager.cc
@@ -66,6 +66,7 @@ OptionManager::OptionManager(bool add_project_options) {
   transitive_matching = std::make_shared<TransitiveMatchingOptions>();
   image_pairs_matching = std::make_shared<ImagePairsMatchingOptions>();
   bundle_adjustment = std::make_shared<BundleAdjustmentOptions>();
+  ba_covariance = std::make_shared<BACovarianceOptions>();
   mapper = std::make_shared<IncrementalPipelineOptions>();
   patch_match_stereo = std::make_shared<mvs::PatchMatchOptions>();
   stereo_fusion = std::make_shared<mvs::StereoFusionOptions>();
@@ -186,6 +187,7 @@ void OptionManager::AddAllOptions() {
   AddTransitiveMatchingOptions();
   AddImagePairsMatchingOptions();
   AddBundleAdjustmentOptions();
+  AddBACovarianceOptions();
   AddMapperOptions();
   AddPatchMatchStereoOptions();
   AddStereoFusionOptions();
@@ -503,6 +505,21 @@ void OptionManager::AddBundleAdjustmentOptions() {
       &bundle_adjustment->max_num_images_direct_sparse_gpu_solver);
 }
 
+void OptionManager::AddBACovarianceOptions() {
+  if (added_ba_covariance_options_) {
+    return;
+  }
+  added_ba_covariance_options_ = true;
+
+  AddAndRegisterRequiredOption("BACovariance.jacobian_path",
+                               &ba_covariance->jacobian_path);
+  AddAndRegisterRequiredOption("BACovariance.covariance_path",
+                               &ba_covariance->covariance_path);
+  AddAndRegisterRequiredOption("BACovariance.index_path",
+                               &ba_covariance->index_path);
+  AddAndRegisterDefaultOption("BACovariance.damping", &ba_covariance->damping);
+}
+
 void OptionManager::AddMapperOptions() {
   if (added_mapper_options_) {
     return;
@@ -800,6 +817,7 @@ void OptionManager::Reset() {
   added_transitive_match_options_ = false;
   added_image_pairs_match_options_ = false;
   added_ba_options_ = false;
+  added_ba_covariance_options_ = false;
   added_mapper_options_ = false;
   added_patch_match_stereo_options_ = false;
   added_stereo_fusion_options_ = false;
@@ -824,6 +842,7 @@ void OptionManager::ResetOptions(const bool reset_paths) {
   *transitive_matching = TransitiveMatchingOptions();
   *image_pairs_matching = ImagePairsMatchingOptions();
   *bundle_adjustment = BundleAdjustmentOptions();
+  *ba_covariance = BACovarianceOptions();
   *mapper = IncrementalPipelineOptions();
   *patch_match_stereo = mvs::PatchMatchOptions();
   *stereo_fusion = mvs::StereoFusionOptions();

--- a/src/colmap/controllers/option_manager.h
+++ b/src/colmap/controllers/option_manager.h
@@ -29,6 +29,7 @@
 
 #pragma once
 
+#include "colmap/estimators/covariance.h"
 #include "colmap/util/logging.h"
 
 #include <memory>
@@ -91,6 +92,7 @@ class OptionManager {
   void AddTransitiveMatchingOptions();
   void AddImagePairsMatchingOptions();
   void AddBundleAdjustmentOptions();
+  void AddBACovarianceOptions();
   void AddMapperOptions();
   void AddPatchMatchStereoOptions();
   void AddStereoFusionOptions();
@@ -134,6 +136,7 @@ class OptionManager {
   std::shared_ptr<ImagePairsMatchingOptions> image_pairs_matching;
 
   std::shared_ptr<BundleAdjustmentOptions> bundle_adjustment;
+  std::shared_ptr<BACovarianceOptions> ba_covariance;
   std::shared_ptr<IncrementalPipelineOptions> mapper;
 
   std::shared_ptr<mvs::PatchMatchOptions> patch_match_stereo;
@@ -176,6 +179,7 @@ class OptionManager {
   bool added_transitive_match_options_;
   bool added_image_pairs_match_options_;
   bool added_ba_options_;
+  bool added_ba_covariance_options_;
   bool added_mapper_options_;
   bool added_patch_match_stereo_options_;
   bool added_stereo_fusion_options_;

--- a/src/colmap/estimators/covariance.cc
+++ b/src/colmap/estimators/covariance.cc
@@ -30,13 +30,58 @@
 #include "colmap/estimators/covariance.h"
 
 #include "colmap/estimators/manifold.h"
+#include "colmap/util/file.h"
 
+#include <fstream>
 #include <unordered_set>
 
 #include <ceres/crs_matrix.h>
 
 namespace colmap {
 namespace {
+
+void WriteSparseMatrix(const Eigen::SparseMatrix<double>& matrix,
+                       const std::string& path) {
+  std::ofstream file(path, std::ios::trunc);
+  THROW_CHECK_FILE_OPEN(file, path);
+  file << matrix.rows() << " " << matrix.cols() << "\n";
+  for (int k = 0; k < matrix.outerSize(); ++k) {
+    for (Eigen::SparseMatrix<double>::InnerIterator it(matrix, k); it; ++it) {
+      file << it.row() << " " << it.col() << " " << it.value() << "\n";
+    }
+  }
+}
+
+template <typename Derived>
+void WriteDenseMatrix(const Eigen::MatrixBase<Derived>& matrix,
+                      const std::string& path) {
+  std::ofstream file(path, std::ios::trunc);
+  THROW_CHECK_FILE_OPEN(file, path);
+  for (int r = 0; r < matrix.rows(); ++r) {
+    for (int c = 0; c < matrix.cols(); ++c) {
+      file << matrix(r, c);
+      if (c + 1 < matrix.cols()) {
+        file << " ";
+      }
+    }
+    file << "\n";
+  }
+}
+
+struct IndexEntry {
+  std::string name;
+  int start = 0;
+  int size = 0;
+};
+
+void WriteIndexFile(const std::vector<IndexEntry>& entries,
+                    const std::string& path) {
+  std::ofstream file(path, std::ios::trunc);
+  THROW_CHECK_FILE_OPEN(file, path);
+  for (const auto& e : entries) {
+    file << e.name << " " << e.start << " " << e.size << "\n";
+  }
+}
 
 bool ComputeSchurComplement(
     bool estimate_point_covs,
@@ -49,7 +94,8 @@ bool ComputeSchurComplement(
     const std::vector<const double*>& others,
     ceres::Problem& problem,
     std::unordered_map<point3D_t, Eigen::MatrixXd>& point_covs,
-    Eigen::SparseMatrix<double>& S) {
+    Eigen::SparseMatrix<double>& S,
+    Eigen::SparseMatrix<double>* J_full_output) {
   VLOG(2) << "Evaluating the Jacobian for Schur elimination";
 
   ceres::Problem::EvaluateOptions eval_options;
@@ -85,6 +131,10 @@ bool ComputeSchurComplement(
       J_full_crs.rows.data(),
       J_full_crs.cols.data(),
       J_full_crs.values.data());
+
+  if (J_full_output != nullptr) {
+    *J_full_output = Eigen::SparseMatrix<double>(J_full);
+  }
 
   if (points.empty()) {
     S = J_full.transpose() * J_full;
@@ -338,47 +388,72 @@ std::optional<BACovariance> EstimateBACovarianceFromProblem(
   int other_num_params = 0;
   std::unordered_map<image_t, std::pair<int, int>> pose_L_start_size;
   std::unordered_map<const double*, std::pair<int, int>> other_L_start_size;
-  for (const auto& point : points) {
-    point_num_params += ParameterBlockTangentSize(problem, point.xyz);
-  }
+  std::unordered_map<point3D_t, std::pair<int, int>> point_L_start_size;
+  std::vector<IndexEntry> index_entries;
+  int col_idx = 0;
+
   if (estimate_pose_covs || estimate_other_covs) {
     pose_L_start_size.reserve(poses.size());
     for (const auto& pose : poses) {
+      const int start = col_idx;
       int num_params = 0;
       if (pose.qvec != nullptr) {
-        num_params += ParameterBlockTangentSize(problem, pose.qvec);
+        const int size = ParameterBlockTangentSize(problem, pose.qvec);
+        index_entries.push_back(
+            {"pose_" + std::to_string(pose.image_id) + "_rot", col_idx, size});
+        col_idx += size;
+        num_params += size;
       }
       if (pose.tvec != nullptr) {
-        num_params += ParameterBlockTangentSize(problem, pose.tvec);
+        const int size = ParameterBlockTangentSize(problem, pose.tvec);
+        index_entries.push_back(
+            {"pose_" + std::to_string(pose.image_id) + "_trans",
+             col_idx,
+             size});
+        col_idx += size;
+        num_params += size;
       }
       pose_L_start_size.emplace(pose.image_id,
-                                std::make_pair(pose_num_params, num_params));
+                                std::make_pair(start, num_params));
       pose_num_params += num_params;
     }
 
-    other_L_start_size.reserve(poses.size());
+    other_L_start_size.reserve(others.size());
     for (const double* other : others) {
-      const int num_params = ParameterBlockTangentSize(problem, other);
-      other_L_start_size.emplace(
-          other,
-          std::make_pair(pose_num_params + other_num_params, num_params));
-      other_num_params += num_params;
+      const int size = ParameterBlockTangentSize(problem, other);
+      index_entries.push_back({"other_param", col_idx, size});
+      other_L_start_size.emplace(other, std::make_pair(col_idx, size));
+      col_idx += size;
+      other_num_params += size;
     }
+  }
+
+  const int point_start = col_idx;
+  for (const auto& point : points) {
+    const int size = ParameterBlockTangentSize(problem, point.xyz);
+    point_L_start_size.emplace(point.point3D_id, std::make_pair(col_idx, size));
+    index_entries.push_back(
+        {"point_" + std::to_string(point.point3D_id), col_idx, size});
+    col_idx += size;
+    point_num_params += size;
   }
 
   std::unordered_map<point3D_t, Eigen::MatrixXd> point_covs;
   Eigen::SparseMatrix<double> S;
-  if (!ComputeSchurComplement(estimate_point_covs,
-                              estimate_pose_covs,
-                              estimate_other_covs,
-                              options.damping,
-                              point_num_params,
-                              points,
-                              poses,
-                              others,
-                              problem,
-                              point_covs,
-                              S)) {
+  Eigen::SparseMatrix<double> J_full;
+  if (!ComputeSchurComplement(
+          estimate_point_covs,
+          estimate_pose_covs,
+          estimate_other_covs,
+          options.damping,
+          point_num_params,
+          points,
+          poses,
+          others,
+          problem,
+          point_covs,
+          S,
+          options.jacobian_path.empty() ? nullptr : &J_full)) {
     return std::nullopt;
   }
 
@@ -401,6 +476,17 @@ std::optional<BACovariance> EstimateBACovarianceFromProblem(
   Eigen::MatrixXd L_inv;
   if (!ComputeLInverse(S, L_inv)) {
     return std::nullopt;
+  }
+
+  if (!options.jacobian_path.empty()) {
+    WriteSparseMatrix(J_full, options.jacobian_path);
+  }
+  if (!options.covariance_path.empty()) {
+    const Eigen::MatrixXd Cov = L_inv.transpose() * L_inv;
+    WriteDenseMatrix(Cov, options.covariance_path);
+  }
+  if (!options.index_path.empty()) {
+    WriteIndexFile(index_entries, options.index_path);
   }
 
   return BACovariance(std::move(point_covs),

--- a/src/colmap/estimators/covariance.h
+++ b/src/colmap/estimators/covariance.h
@@ -34,6 +34,7 @@
 #include "colmap/scene/reconstruction.h"
 
 #include <optional>
+#include <string>
 #include <unordered_map>
 #include <vector>
 
@@ -114,6 +115,12 @@ struct BACovarianceOptions {
   // for custom rig bundle adjustment problems. To be removed when proper rig
   // support is enabled in colmap natively.
   std::vector<internal::PoseParam> experimental_custom_poses;
+
+  // Optional paths to save intermediate matrices.
+  // If empty, the respective matrices are not saved.
+  std::string jacobian_path;
+  std::string covariance_path;
+  std::string index_path;
 };
 
 // Computes covariances for the parameters in a bundle adjustment problem. It is

--- a/src/colmap/exe/colmap.cc
+++ b/src/colmap/exe/colmap.cc
@@ -87,6 +87,7 @@ int main(int argc, char** argv) {
   commands.emplace_back("automatic_reconstructor",
                         &colmap::RunAutomaticReconstructor);
   commands.emplace_back("bundle_adjuster", &colmap::RunBundleAdjuster);
+  commands.emplace_back("covariance_exporter", &colmap::RunCovarianceExporter);
   commands.emplace_back("color_extractor", &colmap::RunColorExtractor);
   commands.emplace_back("database_cleaner", &colmap::RunDatabaseCleaner);
   commands.emplace_back("database_creator", &colmap::RunDatabaseCreator);

--- a/src/colmap/exe/sfm.cc
+++ b/src/colmap/exe/sfm.cc
@@ -181,6 +181,39 @@ int RunBundleAdjuster(int argc, char** argv) {
   return EXIT_SUCCESS;
 }
 
+int RunCovarianceExporter(int argc, char** argv) {
+  std::string input_path;
+
+  OptionManager options;
+  options.AddRequiredOption("input_path", &input_path);
+  options.AddBACovarianceOptions();
+  options.Parse(argc, argv);
+
+  if (!ExistsDir(input_path)) {
+    LOG(ERROR) << "`input_path` is not a directory";
+    return EXIT_FAILURE;
+  }
+
+  Reconstruction reconstruction;
+  reconstruction.Read(input_path);
+
+  BundleAdjustmentConfig config;
+  for (const image_t image_id : reconstruction.RegImageIds()) {
+    config.AddImage(image_id);
+  }
+
+  auto bundle_adjuster = CreateDefaultBundleAdjuster(
+      BundleAdjustmentOptions(), std::move(config), reconstruction);
+
+  if (!EstimateBACovariance(
+          *options.ba_covariance, reconstruction, *bundle_adjuster)) {
+    LOG(ERROR) << "Failed to compute covariance";
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}
+
 int RunColorExtractor(int argc, char** argv) {
   std::string input_path;
   std::string output_path;

--- a/src/colmap/exe/sfm.h
+++ b/src/colmap/exe/sfm.h
@@ -45,6 +45,7 @@ void RunPointTriangulatorImpl(
 
 int RunAutomaticReconstructor(int argc, char** argv);
 int RunBundleAdjuster(int argc, char** argv);
+int RunCovarianceExporter(int argc, char** argv);
 int RunColorExtractor(int argc, char** argv);
 int RunMapper(int argc, char** argv);
 int RunHierarchicalMapper(int argc, char** argv);


### PR DESCRIPTION
## Summary
- avoid referencing 3D point blocks not present in covariance matrix
- align index ordering with Jacobian column order

## Testing
- `./scripts/format/c++.sh >/tmp/format.log && tail -n 20 /tmp/format.log`

------
https://chatgpt.com/codex/tasks/task_e_68434ec00c3483229f33719606e81f35