### PR TITLE
Fix covariance export build

### DIFF
--- a/src/colmap/controllers/option_manager.cc
+++ b/src/colmap/controllers/option_manager.cc
@@ -520,7 +520,8 @@ void OptionManager::AddBACovarianceOptions() {
 
   AddAndRegisterRequiredOption("BACovariance.obs_index_path",
                                &ba_covariance->obs_index_path);
-  
+}
+
 void OptionManager::AddMapperOptions() {
   if (added_mapper_options_) {
     return;

--- a/src/colmap/estimators/covariance.cc
+++ b/src/colmap/estimators/covariance.cc
@@ -29,10 +29,11 @@
 
 #include "colmap/estimators/covariance.h"
 
+#include "colmap/estimators/bundle_adjustment.h"
 #include "colmap/estimators/manifold.h"
 #include "colmap/util/file.h"
 #include "colmap/util/types.h"
-#include "colmap/estimators/bundle_adjustment.h"
+
 #include <fstream>
 #include <unordered_set>
 
@@ -81,6 +82,15 @@ struct ObsIndexEntry {
   point3D_t point3D_id = kInvalidPoint3DId;
   int row = 0;
 };
+
+void WriteIndexFile(const std::vector<IndexEntry>& entries,
+                    const std::string& path) {
+  std::ofstream file(path, std::ios::trunc);
+  THROW_CHECK_FILE_OPEN(file, path);
+  for (const auto& e : entries) {
+    file << e.name << " " << e.start << " " << e.size << "\n";
+  }
+}
 
 void WriteObsIndexFile(const std::vector<ObsIndexEntry>& entries,
                        const std::string& path) {


### PR DESCRIPTION
## Summary
- fix missing closing brace in option manager
- add `WriteIndexFile` helper
- reorder includes in covariance

## Testing
- `ninja -C build src/colmap/controllers/CMakeFiles/colmap_controllers.dir/option_manager.cc.o src/colmap/estimators/CMakeFiles/colmap_estimators.dir/covariance.cc.o`

------
https://chatgpt.com/codex/tasks/task_e_6843b19e4f648322874d6f6e7ea99eb5