### PR TITLE
Add gauge option for covariance_exporter

### DIFF
--- a/processing_steps.txt
+++ b/processing_steps.txt
@@ -27,6 +27,7 @@ colmap bundle_adjuster \
 
 colmap covariance_exporter \
     --input_path $DATASET_PATH/sparse/optimized \
+    --gauge THREE_POINTS \
     --BACovariance.jacobian_path $DATASET_PATH/sparse/results/jacobian.txt \
     --BACovariance.covariance_path $DATASET_PATH/sparse/results/covariance.txt \
     --BACovariance.index_path $DATASET_PATH/sparse/results/index.txt \

--- a/src/colmap/exe/sfm.cc
+++ b/src/colmap/exe/sfm.cc
@@ -183,11 +183,22 @@ int RunBundleAdjuster(int argc, char** argv) {
 
 int RunCovarianceExporter(int argc, char** argv) {
   std::string input_path;
+  std::string gauge_str = "THREE_POINTS";
 
   OptionManager options;
   options.AddRequiredOption("input_path", &input_path);
   options.AddBACovarianceOptions();
+  options.AddDefaultOption(
+      "gauge", &gauge_str, "{THREE_POINTS, TWO_CAMS_FROM_WORLD}");
   options.Parse(argc, argv);
+
+  StringToUpper(&gauge_str);
+  BundleAdjustmentGauge gauge = BundleAdjustmentGauge::THREE_POINTS;
+  try {
+    gauge = BundleAdjustmentGaugeFromString(gauge_str);
+  } catch (const std::exception& e) {
+    LOG(WARNING) << "Invalid gauge specified. Using THREE_POINTS.";
+  }
 
   if (!ExistsDir(input_path)) {
     LOG(ERROR) << "`input_path` is not a directory";
@@ -201,6 +212,7 @@ int RunCovarianceExporter(int argc, char** argv) {
   for (const image_t image_id : reconstruction.RegImageIds()) {
     config.AddImage(image_id);
   }
+  config.FixGauge(gauge);
 
   auto bundle_adjuster = CreateDefaultBundleAdjuster(
       BundleAdjustmentOptions(), std::move(config), reconstruction);


### PR DESCRIPTION
## Summary
- allow choosing gauge for `covariance_exporter`
- set gauge before bundle adjustment
- document gauge option in processing steps

## Testing
- `./scripts/format/c++.sh` *(fails: clang-format version mismatch)*
- `./scripts/format/python.sh` *(fails: ruff version mismatch)*
- `cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=Release -DTESTS_ENABLED=ON -DCUDA_ENABLED=OFF -DGUI_ENABLED=OFF` *(fails: could not find Boost)*

------
https://chatgpt.com/codex/tasks/task_e_6844782a8080832299b10524d8a4d47f