### PR TITLE
Add inner constraints gauge and CLI option

### DIFF
--- a/src/colmap/controllers/bundle_adjustment.cc
+++ b/src/colmap/controllers/bundle_adjustment.cc
@@ -63,8 +63,11 @@ class BundleAdjustmentIterationCallback : public ceres::IterationCallback {
 
 BundleAdjustmentController::BundleAdjustmentController(
     const OptionManager& options,
-    std::shared_ptr<Reconstruction> reconstruction)
-    : options_(options), reconstruction_(std::move(reconstruction)) {}
+    std::shared_ptr<Reconstruction> reconstruction,
+    BundleAdjustmentGauge gauge)
+    : options_(options),
+      reconstruction_(std::move(reconstruction)),
+      gauge_(gauge) {}
 
 void BundleAdjustmentController::Run() {
   THROW_CHECK_NOTNULL(reconstruction_);
@@ -91,7 +94,7 @@ void BundleAdjustmentController::Run() {
   for (const image_t image_id : reconstruction_->RegImageIds()) {
     ba_config.AddImage(image_id);
   }
-  ba_config.FixGauge(BundleAdjustmentGauge::TWO_CAMS_FROM_WORLD);
+  ba_config.FixGauge(gauge_);
 
   // Run bundle adjustment.
   std::unique_ptr<BundleAdjuster> bundle_adjuster = CreateDefaultBundleAdjuster(

--- a/src/colmap/controllers/bundle_adjustment.h
+++ b/src/colmap/controllers/bundle_adjustment.h
@@ -30,6 +30,7 @@
 #pragma once
 
 #include "colmap/controllers/option_manager.h"
+#include "colmap/estimators/bundle_adjustment.h"
 #include "colmap/scene/reconstruction.h"
 #include "colmap/util/base_controller.h"
 
@@ -39,13 +40,15 @@ namespace colmap {
 class BundleAdjustmentController : public BaseController {
  public:
   BundleAdjustmentController(const OptionManager& options,
-                             std::shared_ptr<Reconstruction> reconstruction);
+                             std::shared_ptr<Reconstruction> reconstruction,
+                             BundleAdjustmentGauge gauge);
 
   void Run();
 
  private:
   const OptionManager options_;
   std::shared_ptr<Reconstruction> reconstruction_;
+  BundleAdjustmentGauge gauge_ = BundleAdjustmentGauge::TWO_CAMS_FROM_WORLD;
 };
 
 }  // namespace colmap

--- a/src/colmap/estimators/bundle_adjustment.cc
+++ b/src/colmap/estimators/bundle_adjustment.cc
@@ -32,6 +32,8 @@
 #include "colmap/estimators/alignment.h"
 #include "colmap/estimators/cost_functions.h"
 #include "colmap/estimators/manifold.h"
+#include "colmap/geometry/rigid3.h"
+#include "colmap/geometry/sim3.h"
 #include "colmap/scene/projection.h"
 #include "colmap/sensor/models.h"
 #include "colmap/util/cuda.h"
@@ -630,12 +632,34 @@ void ParameterizePoints(
   }
 }
 
+void ApplyInnerConstraints(Reconstruction& reconstruction,
+                           const BundleAdjustmentConfig& config) {
+  if (config.Images().empty()) {
+    return;
+  }
+
+  const image_t ref_id = *config.Images().begin();
+
+  // Normalize scale and translation of the scene.
+  reconstruction.Normalize(/*fixed_scale=*/false);
+
+  const Rigid3d ref_pose =
+      reconstruction.Image(ref_id).FramePtr()->RigFromWorld();
+
+  const Sim3d world_from_ref(
+      1.0,
+      ref_pose.rotation.conjugate(),
+      -ref_pose.rotation.conjugate() * ref_pose.translation);
+  reconstruction.Transform(world_from_ref);
+}
+
 class DefaultBundleAdjuster : public BundleAdjuster {
  public:
   DefaultBundleAdjuster(BundleAdjustmentOptions options,
                         BundleAdjustmentConfig config,
                         Reconstruction& reconstruction)
       : BundleAdjuster(std::move(options), std::move(config)),
+        reconstruction_(reconstruction),
         loss_function_(std::unique_ptr<ceres::LossFunction>(
             options_.CreateLossFunction())) {
     ceres::Problem::Options problem_options;
@@ -676,6 +700,10 @@ class DefaultBundleAdjuster : public BundleAdjuster {
         options_.CreateSolverOptions(config_, *problem_);
 
     ceres::Solve(solver_options, problem_.get(), &summary);
+
+    if (config_.FixedGauge() == BundleAdjustmentGauge::INNER) {
+      ApplyInnerConstraints(reconstruction_, config_);
+    }
 
     if (options_.print_summary || VLOG_IS_ON(1)) {
       PrintSolverSummary(summary, "Bundle adjustment report");
@@ -869,6 +897,8 @@ class DefaultBundleAdjuster : public BundleAdjuster {
  private:
   std::shared_ptr<ceres::Problem> problem_;
   std::unique_ptr<ceres::LossFunction> loss_function_;
+
+  Reconstruction& reconstruction_;
 
   std::set<camera_t> parameterized_camera_ids_;
   std::set<image_t> parameterized_image_ids_;

--- a/src/colmap/estimators/bundle_adjustment.h
+++ b/src/colmap/estimators/bundle_adjustment.h
@@ -41,8 +41,12 @@
 
 namespace colmap {
 
-MAKE_ENUM_CLASS_OVERLOAD_STREAM(
-    BundleAdjustmentGauge, -1, UNSPECIFIED, TWO_CAMS_FROM_WORLD, THREE_POINTS);
+MAKE_ENUM_CLASS_OVERLOAD_STREAM(BundleAdjustmentGauge,
+                                -1,
+                                UNSPECIFIED,
+                                TWO_CAMS_FROM_WORLD,
+                                THREE_POINTS,
+                                INNER);
 
 // Configuration container to setup bundle adjustment problems.
 class BundleAdjustmentConfig {

--- a/src/colmap/exe/sfm.cc
+++ b/src/colmap/exe/sfm.cc
@@ -153,12 +153,23 @@ int RunAutomaticReconstructor(int argc, char** argv) {
 int RunBundleAdjuster(int argc, char** argv) {
   std::string input_path;
   std::string output_path;
+  std::string gauge_str = "TWO_CAMS_FROM_WORLD";
 
   OptionManager options;
   options.AddRequiredOption("input_path", &input_path);
   options.AddRequiredOption("output_path", &output_path);
   options.AddBundleAdjustmentOptions();
+  options.AddDefaultOption(
+      "gauge", &gauge_str, "{TWO_CAMS_FROM_WORLD, THREE_POINTS, INNER}");
   options.Parse(argc, argv);
+
+  StringToUpper(&gauge_str);
+  BundleAdjustmentGauge gauge = BundleAdjustmentGauge::TWO_CAMS_FROM_WORLD;
+  try {
+    gauge = BundleAdjustmentGaugeFromString(gauge_str);
+  } catch (const std::exception& e) {
+    LOG(WARNING) << "Invalid gauge specified. Using TWO_CAMS_FROM_WORLD.";
+  }
 
   if (!ExistsDir(input_path)) {
     LOG(ERROR) << "`input_path` is not a directory";
@@ -173,7 +184,7 @@ int RunBundleAdjuster(int argc, char** argv) {
   auto reconstruction = std::make_shared<Reconstruction>();
   reconstruction->Read(input_path);
 
-  BundleAdjustmentController ba_controller(options, reconstruction);
+  BundleAdjustmentController ba_controller(options, reconstruction, gauge);
   ba_controller.Run();
 
   reconstruction->Write(output_path);

--- a/src/colmap/ui/bundle_adjustment_widget.cc
+++ b/src/colmap/ui/bundle_adjustment_widget.cc
@@ -105,7 +105,10 @@ void BundleAdjustmentWidget::Run() {
   WriteOptions();
 
   auto thread = std::make_unique<ControllerThread<BundleAdjustmentController>>(
-      std::make_shared<BundleAdjustmentController>(*options_, reconstruction_));
+      std::make_shared<BundleAdjustmentController>(
+          *options_,
+          reconstruction_,
+          BundleAdjustmentGauge::TWO_CAMS_FROM_WORLD));
   thread->AddCallback(Thread::FINISHED_CALLBACK,
                       [this]() { render_action_->trigger(); });
 

--- a/src/pycolmap/estimators/bundle_adjustment.cc
+++ b/src/pycolmap/estimators/bundle_adjustment.cc
@@ -20,7 +20,8 @@ void BindBundleAdjuster(py::module& m) {
           .value("UNSPECIFIED", BundleAdjustmentGauge::UNSPECIFIED)
           .value("TWO_CAMS_FROM_WORLD",
                  BundleAdjustmentGauge::TWO_CAMS_FROM_WORLD)
-          .value("THREE_POINTS", BundleAdjustmentGauge::THREE_POINTS);
+          .value("THREE_POINTS", BundleAdjustmentGauge::THREE_POINTS)
+          .value("INNER", BundleAdjustmentGauge::INNER);
   AddStringToEnumConstructor(PyBundleAdjustmentGauge);
 
   using BACfg = BundleAdjustmentConfig;

--- a/src/pycolmap/pipeline/sfm.cc
+++ b/src/pycolmap/pipeline/sfm.cc
@@ -95,7 +95,10 @@ void BundleAdjustment(const std::shared_ptr<Reconstruction>& reconstruction,
   py::gil_scoped_release release;
   OptionManager option_manager;
   *option_manager.bundle_adjustment = options;
-  BundleAdjustmentController controller(option_manager, reconstruction);
+  BundleAdjustmentController controller(
+      option_manager,
+      reconstruction,
+      BundleAdjustmentGauge::TWO_CAMS_FROM_WORLD);
   controller.Run();
 }
 


### PR DESCRIPTION
## Summary
- add new `INNER` gauge option to bundle adjustment
- expose gauge selection in `colmap bundle_adjuster`
- apply inner constraints after solving when selected
- update controller, UI, and Python bindings for new gauge

## Testing
- `ruff check src/pycolmap/pipeline` *(passes)*


------
https://chatgpt.com/codex/tasks/task_e_68464d31852c8322a53697242ba13d5a