### PR TITLE
Fix inner constraints scale normalization

### DIFF
--- a/src/colmap/estimators/bundle_adjustment.cc
+++ b/src/colmap/estimators/bundle_adjustment.cc
@@ -649,7 +649,7 @@ void ApplyInnerConstraints(Reconstruction& reconstruction,
   const Sim3d world_from_ref(
       1.0,
       ref_pose.rotation.conjugate(),
-      -ref_pose.rotation.conjugate() * ref_pose.translation);
+      ref_pose.rotation.conjugate() * (-ref_pose.translation));
   reconstruction.Transform(world_from_ref);
 }
 


### PR DESCRIPTION
## Summary
- fix unary minus on quaternion when applying inner constraints

## Testing
- `clang-format -i src/colmap/estimators/bundle_adjustment.cc`
- `cmake .. -DCMAKE_BUILD_TYPE=Release` *(fails: Could NOT find Boost)*

------
https://chatgpt.com/codex/tasks/task_e_6847287951d48322994b91ebe20a845d