### PR TITLE
Fix initializer list order warning

### DIFF
--- a/src/colmap/estimators/bundle_adjustment.cc
+++ b/src/colmap/estimators/bundle_adjustment.cc
@@ -659,9 +659,9 @@ class DefaultBundleAdjuster : public BundleAdjuster {
                         BundleAdjustmentConfig config,
                         Reconstruction& reconstruction)
       : BundleAdjuster(std::move(options), std::move(config)),
-        reconstruction_(reconstruction),
         loss_function_(std::unique_ptr<ceres::LossFunction>(
-            options_.CreateLossFunction())) {
+            options_.CreateLossFunction())),
+        reconstruction_(reconstruction) {
     ceres::Problem::Options problem_options;
     problem_options.loss_function_ownership = ceres::DO_NOT_TAKE_OWNERSHIP;
     problem_ = std::make_shared<ceres::Problem>(problem_options);


### PR DESCRIPTION
## Summary
- reorder the initializer list in `DefaultBundleAdjuster` to match the member declaration order

## Testing
- `cmake -B build -S . -GNinja -DTESTS_ENABLED=ON` *(fails: Could not find Boost, Eigen3, etc.)*
- `ninja -C build src/colmap/estimators/CMakeFiles/colmap_estimators.dir/bundle_adjustment.cc.o` *(fails to execute due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68472a720df08322936822dc1b5f0297