### PR TITLE
Implement inner gauge constraints for BA

### DIFF
--- a/doc/cli.rst
+++ b/doc/cli.rst
@@ -24,7 +24,7 @@ Assuming you stored the images of your project in the following structure::
 
 The command for the automatic reconstruction tool would be::
 
-    # The project folder must contain a folder "images" with all the images.
+#The project folder must contain a folder "images" with all the images.
     $ DATASET_PATH=/path/to/project
 
     $ colmap automatic_reconstructor \
@@ -36,7 +36,7 @@ command-line argument. In case you need more control over the individual
 parameters of the reconstruction process, you can execute the following sequence
 of commands as an alternative to the automatic reconstruction command::
 
-    # The project folder must contain a folder "images" with all the images.
+#The project folder must contain a folder "images" with all the images.
     $ DATASET_PATH=/path/to/dataset
 
     $ colmap feature_extractor \
@@ -267,7 +267,9 @@ available as ``colmap [command]``:
 
 - ``bundle_adjuster``: Run global bundle adjustment on a reconstructed scene,
   e.g., when a refinement of the intrinsics is needed or
-  after running the ``image_registrator``.
+  after running the ``image_registrator``. The ``--gauge`` option controls how
+  the similarity ambiguity is handled. Setting ``gauge=INNER`` now enforces
+  inner constraints directly during optimization.
 
 - ``database_cleaner``: Clean specific or all database tables.
 

--- a/src/colmap/estimators/bundle_adjustment.cc
+++ b/src/colmap/estimators/bundle_adjustment.cc
@@ -653,6 +653,94 @@ void ApplyInnerConstraints(Reconstruction& reconstruction,
   reconstruction.Transform(world_from_ref);
 }
 
+namespace {
+
+Eigen::Matrix3d CrossMatrix(const Eigen::Vector3d& v) {
+  Eigen::Matrix3d m;
+  m << 0, -v.z(), v.y(), v.z(), 0, -v.x(), -v.y(), v.x(), 0;
+  return m;
+}
+
+class InnerConstraintsCostFunction : public ceres::CostFunction {
+ public:
+  InnerConstraintsCostFunction(
+      const std::vector<int>& block_sizes,
+      const std::vector<Eigen::Matrix<double, 7, Eigen::Dynamic>>& jacobians)
+      : jacobians_(jacobians) {
+    set_num_residuals(7);
+    *mutable_parameter_block_sizes() = block_sizes;
+  }
+
+  bool Evaluate(double const* const* /*parameters*/,
+                double* residuals,
+                double** jacobians) const override {
+    for (int i = 0; i < 7; ++i) {
+      residuals[i] = 0.0;
+    }
+    if (jacobians != nullptr) {
+      for (size_t i = 0; i < jacobians_.size(); ++i) {
+        if (jacobians[i] != nullptr) {
+          Eigen::Map<Eigen::Matrix<double, 7, Eigen::Dynamic, Eigen::RowMajor>>
+              J(jacobians[i], 7, jacobians_[i].cols());
+          J = jacobians_[i];
+        }
+      }
+    }
+    return true;
+  }
+
+ private:
+  std::vector<Eigen::Matrix<double, 7, Eigen::Dynamic>> jacobians_;
+};
+
+}  // namespace
+
+void FixGaugeWithInnerConstraints(const BundleAdjustmentConfig& config,
+                                  Reconstruction& reconstruction,
+                                  ceres::Problem& problem) {
+  std::vector<double*> parameter_blocks;
+  std::vector<int> block_sizes;
+  std::vector<Eigen::Matrix<double, 7, Eigen::Dynamic>> jacobians;
+
+  for (const image_t image_id : config.Images()) {
+    Image& image = reconstruction.Image(image_id);
+    Rigid3d& pose = image.FramePtr()->RigFromWorld();
+    if (problem.HasParameterBlock(pose.translation.data())) {
+      const Eigen::Matrix3d Rwc = pose.rotation.conjugate().toRotationMatrix();
+      const Eigen::Vector3d C = pose.rotation.conjugate() * (-pose.translation);
+      Eigen::Matrix<double, 7, 3> J;
+      J.block<3, 3>(0, 0) = -Rwc;
+      J.block<3, 3>(3, 0) = -CrossMatrix(C) * Rwc;
+      J.block<1, 3>(6, 0) = -C.transpose() * Rwc;
+      parameter_blocks.push_back(pose.translation.data());
+      block_sizes.push_back(3);
+      jacobians.push_back(J);
+    }
+  }
+
+  for (const point3D_t pid : config.VariablePoints()) {
+    Point3D& p = reconstruction.Point3D(pid);
+    if (problem.HasParameterBlock(p.xyz.data())) {
+      Eigen::Matrix<double, 7, 3> J;
+      J.block<3, 3>(0, 0) = Eigen::Matrix3d::Identity();
+      J.block<3, 3>(3, 0) = CrossMatrix(p.xyz);
+      J.block<1, 3>(6, 0) = p.xyz.transpose();
+      parameter_blocks.push_back(p.xyz.data());
+      block_sizes.push_back(3);
+      jacobians.push_back(J);
+    }
+  }
+
+  if (parameter_blocks.empty()) {
+    return;
+  }
+
+  problem.AddResidualBlock(
+      new InnerConstraintsCostFunction(block_sizes, jacobians),
+      nullptr,
+      parameter_blocks);
+}
+
 class DefaultBundleAdjuster : public BundleAdjuster {
  public:
   DefaultBundleAdjuster(BundleAdjustmentOptions options,
@@ -688,6 +776,10 @@ class DefaultBundleAdjuster : public BundleAdjuster {
         options_, config_, parameterized_image_ids_, reconstruction, *problem_);
     ParameterizePoints(
         config_, point3D_num_observations_, reconstruction, *problem_);
+
+    if (config_.FixedGauge() == BundleAdjustmentGauge::INNER) {
+      FixGaugeWithInnerConstraints(config_, reconstruction, *problem_);
+    }
   }
 
   ceres::Solver::Summary Solve() override {
@@ -700,10 +792,6 @@ class DefaultBundleAdjuster : public BundleAdjuster {
         options_.CreateSolverOptions(config_, *problem_);
 
     ceres::Solve(solver_options, problem_.get(), &summary);
-
-    if (config_.FixedGauge() == BundleAdjustmentGauge::INNER) {
-      ApplyInnerConstraints(reconstruction_, config_);
-    }
 
     if (options_.print_summary || VLOG_IS_ON(1)) {
       PrintSolverSummary(summary, "Bundle adjustment report");

--- a/src/colmap/scene/reconstruction_test.cc
+++ b/src/colmap/scene/reconstruction_test.cc
@@ -715,5 +715,44 @@ TEST(Reconstruction, DeleteAllPoints2DAndPoints3D) {
   ExpectValidPtrs(reconstruction);
 }
 
+TEST(Reconstruction, BundleAdjustmentInnerGauge) {
+  Reconstruction reconstruction;
+  SyntheticDatasetOptions opts;
+  opts.num_rigs = 1;
+  opts.num_cameras_per_rig = 1;
+  opts.num_frames_per_rig = 5;
+  opts.num_points3D = 20;
+  opts.point2D_stddev = 0;
+  SynthesizeDataset(opts, &reconstruction);
+  const Reconstruction orig = reconstruction;
+
+  BundleAdjustmentConfig cfg;
+  for (const image_t id : reconstruction.RegImageIds()) {
+    cfg.AddImage(id);
+  }
+  cfg.FixGauge(BundleAdjustmentGauge::INNER);
+
+  BundleAdjustmentOptions ba_opts;
+  std::unique_ptr<BundleAdjuster> ba =
+      CreateDefaultBundleAdjuster(ba_opts, cfg, reconstruction);
+  ba->Solve();
+
+  const auto orig_centroid = orig.ComputeCentroid(0.0, 1.0);
+  const auto new_centroid = reconstruction.ComputeCentroid(0.0, 1.0);
+  EXPECT_NEAR((orig_centroid - new_centroid).norm(), 0, 1e-6);
+
+  const image_t ref_id = *reconstruction.RegImageIds().begin();
+  const auto& ref_pose_orig = orig.Image(ref_id).FramePtr()->RigFromWorld();
+  const auto& ref_pose_new =
+      reconstruction.Image(ref_id).FramePtr()->RigFromWorld();
+  EXPECT_LT(ref_pose_orig.rotation.angularDistance(ref_pose_new.rotation),
+            1e-6);
+
+  const double orig_scale = orig.ComputeBoundingBox(0.0, 1.0).diagonal().norm();
+  const double new_scale =
+      reconstruction.ComputeBoundingBox(0.0, 1.0).diagonal().norm();
+  EXPECT_NEAR(new_scale / orig_scale, 1.0, 1e-6);
+}
+
 }  // namespace
 }  // namespace colmap

--- a/src/pycolmap/estimators/bundle_adjustment.cc
+++ b/src/pycolmap/estimators/bundle_adjustment.cc
@@ -21,7 +21,9 @@ void BindBundleAdjuster(py::module& m) {
           .value("TWO_CAMS_FROM_WORLD",
                  BundleAdjustmentGauge::TWO_CAMS_FROM_WORLD)
           .value("THREE_POINTS", BundleAdjustmentGauge::THREE_POINTS)
-          .value("INNER", BundleAdjustmentGauge::INNER);
+          .value("INNER",
+                 BundleAdjustmentGauge::INNER,
+                 "Apply inner constraints during optimization");
   AddStringToEnumConstructor(PyBundleAdjustmentGauge);
 
   using BACfg = BundleAdjustmentConfig;


### PR DESCRIPTION
## Summary
- add inner constraint helper and cost function
- call helper when gauge=INNER
- update Python binding docstrings and CLI docs
- add unit test for inner gauge preservation

## Testing
- `clang-format -i src/colmap/estimators/bundle_adjustment.cc src/pycolmap/estimators/bundle_adjustment.cc src/colmap/scene/reconstruction_test.cc doc/cli.rst`

------
https://chatgpt.com/codex/tasks/task_e_6848b7b5fcd08322a6c00b8aece9d188