### PR TITLE
Update gauge option for covariance exporter

### DIFF
--- a/src/colmap/exe/sfm.cc
+++ b/src/colmap/exe/sfm.cc
@@ -200,7 +200,8 @@ int RunCovarianceExporter(int argc, char** argv) {
   options.AddRequiredOption("input_path", &input_path);
   options.AddBACovarianceOptions();
   options.AddDefaultOption(
-      "gauge", &gauge_str, "{THREE_POINTS, TWO_CAMS_FROM_WORLD}");
+      "gauge", &gauge_str,
+      "{THREE_POINTS, TWO_CAMS_FROM_WORLD, INNER}");
   options.Parse(argc, argv);
 
   StringToUpper(&gauge_str);


### PR DESCRIPTION
## Summary
- accept `INNER` gauge option in covariance exporter

## Testing
- `apt-get install -y colmap` *(fail: missing new option)*
- `ninja -j5 colmap_main` *(fails: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6848f4e90100832297f07069cd701e6e