### PR TITLE
Fix inner gauge residual update

### DIFF
--- a/src/colmap/estimators/bundle_adjustment.cc
+++ b/src/colmap/estimators/bundle_adjustment.cc
@@ -250,6 +250,8 @@ const BundleAdjustmentOptions& BundleAdjuster::Options() const {
 
 const BundleAdjustmentConfig& BundleAdjuster::Config() const { return config_; }
 
+void BundleAdjuster::UpdateInnerConstraints() {}
+
 ////////////////////////////////////////////////////////////////////////////////
 // BundleAdjustmentOptions
 ////////////////////////////////////////////////////////////////////////////////
@@ -699,9 +701,10 @@ class InnerConstraintsCostFunction : public ceres::CostFunction {
 
 }  // namespace
 
-void FixGaugeWithInnerConstraints(const BundleAdjustmentConfig& config,
-                                  Reconstruction& reconstruction,
-                                  ceres::Problem& problem) {
+ceres::ResidualBlockId FixGaugeWithInnerConstraints(
+    const BundleAdjustmentConfig& config,
+    Reconstruction& reconstruction,
+    ceres::Problem& problem) {
   std::vector<double*> parameter_blocks;
   std::vector<int> block_sizes;
   std::vector<Eigen::Matrix<double, 7, Eigen::Dynamic>> jacobians;
@@ -736,10 +739,10 @@ void FixGaugeWithInnerConstraints(const BundleAdjustmentConfig& config,
   }
 
   if (parameter_blocks.empty()) {
-    return;
+    return nullptr;
   }
 
-  problem.AddResidualBlock(
+  return problem.AddResidualBlock(
       new InnerConstraintsCostFunction(block_sizes, jacobians),
       nullptr,
       parameter_blocks);
@@ -786,7 +789,8 @@ class DefaultBundleAdjuster : public BundleAdjuster {
         config_, point3D_num_observations_, reconstruction, *problem_);
 
     if (config_.FixedGauge() == BundleAdjustmentGauge::INNER) {
-      FixGaugeWithInnerConstraints(config_, reconstruction, *problem_);
+      inner_constraints_residual_id_ =
+          FixGaugeWithInnerConstraints(config_, reconstruction, *problem_);
     }
   }
 
@@ -803,6 +807,7 @@ class DefaultBundleAdjuster : public BundleAdjuster {
 
     if (config_.FixedGauge() == BundleAdjustmentGauge::INNER) {
       reconstruction_.Transform(Inverse(inner_tform_));
+      UpdateInnerConstraints();
     }
 
     if (options_.print_summary || VLOG_IS_ON(1)) {
@@ -813,6 +818,17 @@ class DefaultBundleAdjuster : public BundleAdjuster {
   }
 
   std::shared_ptr<ceres::Problem>& Problem() override { return problem_; }
+
+  void UpdateInnerConstraints() override {
+    if (config_.FixedGauge() != BundleAdjustmentGauge::INNER) {
+      return;
+    }
+    if (inner_constraints_residual_id_ != nullptr) {
+      problem_->RemoveResidualBlock(inner_constraints_residual_id_);
+    }
+    inner_constraints_residual_id_ =
+        FixGaugeWithInnerConstraints(config_, reconstruction_, *problem_);
+  }
 
   void AddImageToProblem(const image_t image_id,
                          Reconstruction& reconstruction) {
@@ -1001,6 +1017,7 @@ class DefaultBundleAdjuster : public BundleAdjuster {
   Reconstruction& reconstruction_;
 
   Sim3d inner_tform_;
+  ceres::ResidualBlockId inner_constraints_residual_id_ = nullptr;
 
   std::set<camera_t> parameterized_camera_ids_;
   std::set<image_t> parameterized_image_ids_;

--- a/src/colmap/estimators/bundle_adjustment.h
+++ b/src/colmap/estimators/bundle_adjustment.h
@@ -219,6 +219,11 @@ class BundleAdjuster {
   virtual ceres::Solver::Summary Solve() = 0;
   virtual std::shared_ptr<ceres::Problem>& Problem() = 0;
 
+  // Refresh any gauge constraints that depend on absolute poses after the
+  // reconstruction has been transformed. Default implementation does nothing
+  // and is overridden by specific bundle adjusters when required.
+  virtual void UpdateInnerConstraints();
+
   const BundleAdjustmentOptions& Options() const;
   const BundleAdjustmentConfig& Config() const;
 

--- a/src/colmap/estimators/covariance.cc
+++ b/src/colmap/estimators/covariance.cc
@@ -413,6 +413,7 @@ std::optional<BACovariance> EstimateBACovariance(
     const BACovarianceOptions& options,
     const Reconstruction& reconstruction,
     BundleAdjuster& bundle_adjuster) {
+  bundle_adjuster.UpdateInnerConstraints();
   ceres::Problem& problem = *THROW_CHECK_NOTNULL(bundle_adjuster.Problem());
   if (!options.obs_index_path.empty()) {
     auto obs_index = BuildObsIndex(reconstruction, bundle_adjuster.Config());

--- a/src/colmap/estimators/covariance_test.cc
+++ b/src/colmap/estimators/covariance_test.cc
@@ -345,5 +345,53 @@ INSTANTIATE_TEST_SUITE_P(
           return std::make_pair(options, test_options);
         }()));
 
+TEST(BACovariance, InnerGaugeComparable) {
+  SetPRNGSeed(42);
+
+  auto run_test = [](BundleAdjustmentGauge gauge) {
+    Reconstruction recon;
+    SyntheticDatasetOptions opts;
+    opts.num_rigs = 1;
+    opts.num_cameras_per_rig = 1;
+    opts.num_frames_per_rig = 5;
+    opts.num_points3D = 50;
+    opts.point2D_stddev = 0.01;
+    SynthesizeDataset(opts, &recon);
+
+    BundleAdjustmentConfig cfg;
+    for (const auto& [id, _] : recon.Images()) {
+      cfg.AddImage(id);
+    }
+    cfg.FixGauge(gauge);
+
+    BundleAdjustmentOptions ba_opts;
+    std::unique_ptr<BundleAdjuster> ba =
+        CreateDefaultBundleAdjuster(ba_opts, cfg, recon);
+    const auto summary = ba->Solve();
+    EXPECT_TRUE(summary.IsSolutionUsable());
+
+    BACovarianceOptions cov_opts;
+    cov_opts.params = BACovarianceOptions::Params::POINTS;
+    const auto cov = EstimateBACovariance(cov_opts, recon, *ba);
+    EXPECT_TRUE(cov.has_value());
+
+    double trace_sum = 0.0;
+    size_t count = 0;
+    for (const auto& [pid, _] : recon.Points3D()) {
+      const auto pcov = cov->GetPointCov(pid);
+      if (pcov.has_value()) {
+        trace_sum += pcov->trace();
+        ++count;
+      }
+    }
+    return trace_sum / std::max<size_t>(1, count);
+  };
+
+  const double cov_three = run_test(BundleAdjustmentGauge::THREE_POINTS);
+  const double cov_inner = run_test(BundleAdjustmentGauge::INNER);
+
+  EXPECT_NEAR(cov_inner, cov_three, 0.1 * cov_three);
+}
+
 }  // namespace
 }  // namespace colmap


### PR DESCRIPTION
## Summary
- store residual block ID for the inner gauge constraint
- recompute inner gauge constraint after solving bundle adjustment
- expose `UpdateInnerConstraints` helper and use in covariance estimation
- add unit test checking covariance with INNER gauge

## Testing
- `clang-format` (via scripts/format/c++.sh)
- `cmake .. -GNinja` *(fails: Could NOT find Boost...)*
- `ninja -j4` *(failed: command not fully captured)*

------
https://chatgpt.com/codex/tasks/task_e_6848febb2b0c83229fed636402110990