### PR TITLE
Fix link error for covariance exporter

### DIFF
--- a/src/colmap/exe/CMakeLists.txt
+++ b/src/colmap/exe/CMakeLists.txt
@@ -82,6 +82,7 @@ COLMAP_ADD_EXECUTABLE(
         vocab_tree.cc
     LINK_LIBS
         colmap_controllers
+        colmap_estimators
         colmap_retrieval
         colmap_scene
         colmap_sfm


### PR DESCRIPTION
## Summary
- link `colmap_estimators` in the main executable

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68490cea72708322831fc614dfc6a7c8