### PR TITLE
Fix ApplyInnerConstraints linkage

### DIFF
--- a/src/colmap/estimators/bundle_adjustment.cc
+++ b/src/colmap/estimators/bundle_adjustment.cc
@@ -634,6 +634,8 @@ void ParameterizePoints(
   }
 }
 
+}  // namespace
+
 Sim3d ApplyInnerConstraints(Reconstruction& reconstruction,
                             const BundleAdjustmentConfig& config) {
   if (config.Images().empty()) {


### PR DESCRIPTION
## Summary
- ensure `ApplyInnerConstraints` is defined outside of anonymous namespace so it's visible to the executable

## Testing
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68490f529c808322a32ab242a6f28565