### PR TITLE
Fix namespace scope in bundle_adjustment.cc

### DIFF
--- a/src/colmap/estimators/bundle_adjustment.cc
+++ b/src/colmap/estimators/bundle_adjustment.cc
@@ -1206,8 +1206,6 @@ class PosePriorBundleAdjuster : public BundleAdjuster {
   Sim3d normalized_from_metric_;
 };
 
-}  // namespace
-
 std::unique_ptr<BundleAdjuster> CreateDefaultBundleAdjuster(
     BundleAdjustmentOptions options,
     BundleAdjustmentConfig config,


### PR DESCRIPTION
## Summary
- remove stray namespace closure that left functions outside `colmap`

## Testing
- `cmake .. -GNinja` *(fails: Could NOT find Qt5)*

------
https://chatgpt.com/codex/tasks/task_e_68491319e9a08322a6ac2184942e29fc