### PR TITLE
Fix redundant inner constraint transform

### DIFF
--- a/src/colmap/exe/sfm.cc
+++ b/src/colmap/exe/sfm.cc
@@ -230,18 +230,8 @@ int RunCovarianceExporter(int argc, char** argv) {
   }
   config.FixGauge(gauge);
 
-  Sim3d inner_tform;
-  if (gauge == BundleAdjustmentGauge::INNER) {
-    inner_tform = ApplyInnerConstraints(reconstruction, config);
-  }
-
   auto bundle_adjuster = CreateDefaultBundleAdjuster(
       BundleAdjustmentOptions(), std::move(config), reconstruction);
-
-  if (gauge == BundleAdjustmentGauge::INNER) {
-    reconstruction.Transform(Inverse(inner_tform));
-    bundle_adjuster->UpdateInnerConstraints();
-  }
 
   if (!EstimateBACovariance(
           *options.ba_covariance, reconstruction, *bundle_adjuster)) {


### PR DESCRIPTION
## Summary
- avoid double application of `ApplyInnerConstraints` in `RunCovarianceExporter`

## Testing
- `clang-format -i src/colmap/exe/sfm.cc`

------
https://chatgpt.com/codex/tasks/task_e_684c3508562483228b2b3025b70146cb