### PR TITLE
Fix covariance exporter gauge handling

### DIFF
--- a/src/colmap/exe/sfm.cc
+++ b/src/colmap/exe/sfm.cc
@@ -230,8 +230,14 @@ int RunCovarianceExporter(int argc, char** argv) {
   }
   config.FixGauge(gauge);
 
+  BundleAdjustmentOptions ba_options;
+  ba_options.solver_options.max_num_iterations = 0;
   auto bundle_adjuster = CreateDefaultBundleAdjuster(
-      BundleAdjustmentOptions(), std::move(config), reconstruction);
+      ba_options, std::move(config), reconstruction);
+
+  // Run a dummy solve to ensure gauge transforms are consistently applied and
+  // reverted before computing the covariance.
+  bundle_adjuster->Solve();
 
   if (!EstimateBACovariance(
           *options.ba_covariance, reconstruction, *bundle_adjuster)) {


### PR DESCRIPTION
## Summary
- ensure gauge transformations are applied and reverted when exporting
  covariance data

## Testing
- `pytest python/examples/custom_incremental_pipeline_test.py::test_without_noise -vv` *(fails: ModuleNotFoundError: No module named 'pycolmap')*

------
https://chatgpt.com/codex/tasks/task_e_684c3debac9083228f11498751b1244c