### PR TITLE
Optimize before covariance export

### DIFF
--- a/processing_steps.txt
+++ b/processing_steps.txt
@@ -25,17 +25,11 @@ colmap mapper \
 
 {TWO_CAMS_FROM_WORLD, THREE_POINTS, INNER}
 
-# 5. Global bundle adjustment on the reconstructed scene.
-mkdir $DATASET_PATH/sparse/optimized
-colmap bundle_adjuster \
-    --gauge INNER \
-    --input_path $DATASET_PATH/sparse/1 \
-    --output_path $DATASET_PATH/sparse/optimized
-
-
+# 5. Export covariances. The exporter now performs bundle adjustment
+#    internally, so no separate optimization step is required.
 mkdir $DATASET_PATH/sparse/results
 colmap covariance_exporter \
-    --input_path $DATASET_PATH/sparse/optimized \
+    --input_path $DATASET_PATH/sparse/1 \
     --gauge INNER \
     --BACovariance.jacobian_path $DATASET_PATH/sparse/results/jacobian.txt \
     --BACovariance.covariance_path $DATASET_PATH/sparse/results/covariance.txt \
@@ -49,5 +43,5 @@ jac_path = data_dir / "sparse/results/jacobian.txt"
 cov_path = data_dir / "sparse/results/covariance.txt"
 index_path = data_dir / "sparse/results/index.txt"
 obs_index_path = data_dir / "sparse/results/obs_index.txt"
-model_path = data_dir / "sparse/optimized"
+model_path = data_dir / "sparse/1"
 image_id = 5  # image to analyse

--- a/src/colmap/exe/sfm.cc
+++ b/src/colmap/exe/sfm.cc
@@ -203,6 +203,7 @@ int RunCovarianceExporter(int argc, char** argv) {
 
   OptionManager options;
   options.AddRequiredOption("input_path", &input_path);
+  options.AddBundleAdjustmentOptions();
   options.AddBACovarianceOptions();
   options.AddDefaultOption(
       "gauge", &gauge_str, "{THREE_POINTS, TWO_CAMS_FROM_WORLD, INNER}");
@@ -230,13 +231,13 @@ int RunCovarianceExporter(int argc, char** argv) {
   }
   config.FixGauge(gauge);
 
-  BundleAdjustmentOptions ba_options;
-  ba_options.solver_options.max_num_iterations = 0;
+  BundleAdjustmentOptions ba_options = *options.bundle_adjustment;
   auto bundle_adjuster = CreateDefaultBundleAdjuster(
       ba_options, std::move(config), reconstruction);
 
-  // Run a dummy solve to ensure gauge transforms are consistently applied and
-  // reverted before computing the covariance.
+  // Run a full optimization so that the covariance is computed for the
+  // refined reconstruction and the gauge transformations are correctly
+  // applied and reverted inside the bundle adjuster.
   bundle_adjuster->Solve();
 
   if (!EstimateBACovariance(


### PR DESCRIPTION
## Summary
- run full bundle adjustment in covariance exporter
- parse bundle adjustment options
- update processing steps to remove dedicated bundle_adjuster step

## Testing
- `clang-format -i src/colmap/exe/sfm.cc`


------
https://chatgpt.com/codex/tasks/task_e_684c430421788322a204f2bdb1e598a6