### PR TITLE
Fix quaternion minus Jacobian pointer

### DIFF
--- a/src/colmap/estimators/bundle_adjustment.cc
+++ b/src/colmap/estimators/bundle_adjustment.cc
@@ -712,9 +712,9 @@ ceres::ResidualBlockId FixGaugeWithInnerConstraints(
       J_local.block<3, 3>(3, 0) = -cross_C_sq * Rwc;
       J_local.block<1, 3>(6, 0) = -C.transpose() * cross_C * Rwc;
 
-      Eigen::Matrix<double, 3, 4> minus_jacobian;
-      ceres::internal::ComputeSphereManifoldMinusJacobian(pose.rotation.coeffs(),
-                                                          &minus_jacobian);
+      Eigen::Matrix<double, 3, 4, Eigen::RowMajor> minus_jacobian;
+      ceres::internal::ComputeSphereManifoldMinusJacobian(
+          pose.rotation.coeffs().data(), minus_jacobian.data());
       Eigen::Matrix<double, 7, 4> J = J_local * minus_jacobian;
 
       parameter_blocks.push_back(pose.rotation.coeffs().data());


### PR DESCRIPTION
## Summary
- fix quaternion minus Jacobian pointer in bundle adjustment

## Testing
- `./scripts/format/c++.sh` *(fails: clang-format version mismatch)*
- `./scripts/format/python.sh` *(fails: ruff version mismatch)*
- `cmake -S . -B build -DTESTS_ENABLED=OFF` *(fails: Could NOT find Boost)*

------
https://chatgpt.com/codex/tasks/task_e_684e35d8caac83229b6a8e1f101e2bf9